### PR TITLE
Replace v-click-outside with vue-clickaway

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "chartist": "^0.10.1",
-    "v-click-outside": "0.0.8",
+    "vue-clickaway": "^2.1.0",
     "vue": "^2.3.0",
     "vue-router": "^2.2.0"
   },

--- a/src/components/Dashboard/Layout/TopNavbar.vue
+++ b/src/components/Dashboard/Layout/TopNavbar.vue
@@ -25,14 +25,6 @@
                <li><a href="#">Notification 4</a></li>
                <li><a href="#">Another notification</a></li>
              </drop-down>
-
-             <drop-down title="5 Alerts" icon="ti-bell">
-               <li><a href="#">Notification 1</a></li>
-               <li><a href="#">Notification 2</a></li>
-               <li><a href="#">Notification 3</a></li>
-               <li><a href="#">Notification 4</a></li>
-               <li><a href="#">Another notification</a></li>
-             </drop-down>
           <li>
             <a href="#" class="btn-rotate">
               <i class="ti-settings"></i>

--- a/src/components/Dashboard/Layout/TopNavbar.vue
+++ b/src/components/Dashboard/Layout/TopNavbar.vue
@@ -25,6 +25,14 @@
                <li><a href="#">Notification 4</a></li>
                <li><a href="#">Another notification</a></li>
              </drop-down>
+
+             <drop-down title="5 Alerts" icon="ti-bell">
+               <li><a href="#">Notification 1</a></li>
+               <li><a href="#">Notification 2</a></li>
+               <li><a href="#">Notification 3</a></li>
+               <li><a href="#">Notification 4</a></li>
+               <li><a href="#">Another notification</a></li>
+             </drop-down>
           <li>
             <a href="#" class="btn-rotate">
               <i class="ti-settings"></i>

--- a/src/components/UIComponents/Dropdown.vue
+++ b/src/components/UIComponents/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="dropdown" :class="{open:isOpen}" @click.stop="toggleDropDown" v-click-outside="closeDropDown">
+  <li class="dropdown" :class="{open:isOpen}" @click="toggleDropDown" v-click-outside="closeDropDown">
     <a class="dropdown-toggle btn-rotate" data-toggle="dropdown" href="javascript:void(0)">
       <slot name="title">
         <i :class="icon"></i>

--- a/src/globalDirectives.js
+++ b/src/globalDirectives.js
@@ -1,0 +1,13 @@
+import { directive as vClickOutside } from 'vue-clickaway'
+
+/**
+ * You can register global components here and use them as a plugin in your main Vue instance
+ */
+
+const GlobalDirectives = {
+  install (Vue) {
+    Vue.directive('click-outside', vClickOutside)
+  }
+}
+
+export default GlobalDirectives

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import vClickOutside from 'v-click-outside'
 
 // Plugins
 import GlobalComponents from './globalComponents'
+import GlobalDirectives from './globalDirectives'
 import Notifications from './components/UIComponents/NotificationPlugin'
 import SideBar from './components/UIComponents/SidebarPlugin'
 import App from './App'
@@ -20,7 +20,7 @@ import 'es6-promise/auto'
 // plugin setup
 Vue.use(VueRouter)
 Vue.use(GlobalComponents)
-Vue.use(vClickOutside)
+Vue.use(GlobalDirectives)
 Vue.use(Notifications)
 Vue.use(SideBar)
 


### PR DESCRIPTION
When you have more than one dropdown and open both, the current v-click-outside plugin does not close both if you click outside, just close the latest.

The vue-clickaway package implements as a directive, so I created a globalDirectives.js file to declare and install directives and then apply them as plugins on the main.js file.